### PR TITLE
ci: adopt consolidated ospo-reusable-workflows release.yaml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,68 +10,21 @@ permissions:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
+      contents: write # Create release and push tags (including major-version moving tag)
+      pull-requests: read # Read PR labels for release-drafter
+      packages: write # Push container image to ghcr.io
+      id-token: write # Federate for artifact attestation
+      attestations: write # Generate build provenance attestations
+      discussions: write # Create release announcement discussion
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-  release_image:
-    needs: release
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
-    with:
       image-name: ${{ github.repository_owner }}/stale_repos
-      full-tag: ${{ needs.release.outputs.full-tag }}
-      short-tag: ${{ needs.release.outputs.short-tag }}
+      create-attestation: true
+      create-discussion: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-      image-registry: ghcr.io
-      image-registry-username: ${{ github.actor }}
       image-registry-password: ${{ secrets.GITHUB_TOKEN }}
-  update_major_tag:
-    needs: release
-    if: ${{ needs.release.outputs.full-tag != '' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-tags: true
-          ref: ${{ needs.release.outputs.full-tag }}
-          persist-credentials: true
-
-      - name: Force update major tag
-        run: |
-          git tag -f "${SHORT}" "${FULL}"
-          git push -f origin "${SHORT}"
-        env:
-          SHORT: ${{ needs.release.outputs.short-tag }}
-          FULL: ${{ needs.release.outputs.full-tag  }}
-
-  release_discussion:
-    needs: release
-    permissions:
-      contents: read
-      discussions: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-discussion.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
-    with:
-      full-tag: ${{ needs.release.outputs.full-tag }}
-      body: ${{ needs.release.outputs.body }}
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
       discussion-repository-id: ${{ secrets.RELEASE_DISCUSSION_REPOSITORY_ID }}
       discussion-category-id: ${{ secrets.RELEASE_DISCUSSION_CATEGORY_ID }}


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Collapse the three legacy `release` / `release_image` / `release_discussion` job calls **plus the bespoke `update_major_tag` job** into a single call to the consolidated `release.yaml` reusable workflow at **v1.0.0** (`592067a6...`). The new workflow handles GitHub release creation, container image build/push to GHCR, build provenance attestation, the announcement discussion, **and pushing the major-version moving tag**, in one draft-first pipeline.

Also add a **"💥 Breaking Changes"** category to `release-drafter.yml`, matching the upstream release-drafter template (github-community-projects/ospo-reusable-workflows#134). The `breaking` label was already wired up under `version-resolver.major`, so this just surfaces those PRs in their own changelog section.

### Notes for reviewers

- The reusable workflow's `create_release` tags both the full version (e.g. `v1.2.3`) and the short/major moving tag (e.g. `v1`) and force-pushes both. The deleted `update_major_tag` job did exactly that for the major tag, so behavior is preserved — but worth a careful look at the next release to confirm the major tag does move as expected.
- `image-name` is preserved as `${{ github.repository_owner }}/stale_repos` (underscore form) so the published image at `ghcr.io/github-community-projects/stale_repos` stays at the exact same path as before.
- The job-level permission block now lists the union of what the called workflow's internal jobs need. A `uses:` caller can only grant — never expand — what the reusable workflow requests, so missing perms here silently disable features instead of erroring.
- `image-registry` / `image-registry-username` moved from `secrets:` to inputs in v1.0.0 and default to `ghcr.io` / `github.actor`. Both defaults match the previous values, so the inputs are omitted.
- `image-registry-password` stays a secret and continues using `GITHUB_TOKEN` for GHCR pushes.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

## Testing

- `make lint` — clean (mypy 0 issues across 10 source files, black 10 files unchanged).
- `make test` — 41 tests + 6 subtests pass, coverage 89.81%.
- `npx prettier --check .github/workflows/release.yml .github/release-drafter.yml` — clean (super-linter runs prettier on YAML).
- End-to-end release flow is not exercised locally; first real validation will be the next merged PR carrying a `feature` / `fix` / `breaking` / `vuln` / `release` label that fires `pull_request_target: closed`. Watch for: draft release created by release-drafter, full + short tags both pushed by `create_release`, container image published to `ghcr.io/$OWNER/stale_repos`, build provenance attestation succeeding, release announcement discussion created (if `RELEASE_DISCUSSION_*` secrets are set), then `publish_release` flipping the draft to published.