### PR TITLE
test: raise coverage to 100% (and fix output_to_json metric gating)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [run]
 omit = test*.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	uv run python -m pytest -v --cov=. --cov-config=.coveragerc --cov-fail-under=80 --cov-report term-missing
+	uv run python -m pytest -v --cov=. --cov-config=.coveragerc --cov-fail-under=100 --cov-report term-missing
 
 .PHONY: clean
 clean:

--- a/stale_repos.py
+++ b/stale_repos.py
@@ -73,7 +73,7 @@ def main():  # pragma: no cover
     )
 
     if inactive_repos or not skip_empty_reports:
-        output_to_json(inactive_repos)
+        output_to_json(inactive_repos, additional_metrics=additional_metrics)
         write_to_markdown(
             inactive_repos,
             inactive_days_threshold,
@@ -242,7 +242,7 @@ def get_active_date(repo):
     return active_date
 
 
-def output_to_json(inactive_repos, file=None):
+def output_to_json(inactive_repos, file=None, additional_metrics=None):
     """Convert the list of inactive repos to a json string.
 
     Args:
@@ -250,6 +250,12 @@ def output_to_json(inactive_repos, file=None):
             days inactive, the date of the last push,
             visibility of the repository (public/private),
             days since the last release, and days since the last pr.
+        file: An optional open file object to write the JSON to. If not
+            provided, a new file named "stale_repos.json" is opened.
+        additional_metrics: An optional list of additional metrics to include
+            in the JSON. Supported values: "release", "pr". When omitted, only
+            the core fields are emitted (matching the markdown writer's
+            behavior).
 
     Returns:
         JSON formatted string of the list of inactive repos.
@@ -273,10 +279,13 @@ def output_to_json(inactive_repos, file=None):
             "lastPushDate": repo_data["last_push_date"],
             "visibility": repo_data["visibility"],
         }
-        if "release" in repo_data:
-            repo_json["daysSinceLastRelease"] = repo_data["days_since_last_release"]
-        if "pr" in repo_data:
-            repo_json["daysSinceLastPR"] = repo_data["days_since_last_pr"]
+        if additional_metrics:
+            if "release" in additional_metrics:
+                repo_json["daysSinceLastRelease"] = repo_data.get(
+                    "days_since_last_release"
+                )
+            if "pr" in additional_metrics:
+                repo_json["daysSinceLastPR"] = repo_data.get("days_since_last_pr")
         inactive_repos_json.append(repo_json)
     inactive_repos_json = json.dumps(inactive_repos_json)
 

--- a/test_auth.py
+++ b/test_auth.py
@@ -77,6 +77,18 @@ class TestAuth(unittest.TestCase):
         )
         self.assertEqual(result, mock)
 
+    @patch("github3.login")
+    def test_auth_to_github_raises_when_connection_is_none(self, mock_login):
+        """
+        Test the auth_to_github function raises ValueError when github3.login returns None.
+        """
+        mock_login.return_value = None
+        with self.assertRaises(ValueError) as context_manager:
+            auth.auth_to_github("token", None, None, b"", "", False)
+        self.assertEqual(
+            str(context_manager.exception), "Unable to authenticate to GitHub"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_env.py
+++ b/test_env.py
@@ -195,6 +195,17 @@ class TestGetEnvVars(unittest.TestCase):
         result = get_env_vars(True)
         self.assertEqual(str(result), str(expected_result))
 
+    @patch.dict(
+        os.environ,
+        {"GH_TOKEN": "TOKEN"},
+        clear=True,
+    )
+    @patch("env.load_dotenv")
+    def test_get_env_vars_loads_dotenv_when_not_test(self, mock_load_dotenv):
+        """Test that get_env_vars loads the .env file when test is False."""
+        get_env_vars(test=False)
+        mock_load_dotenv.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -812,28 +812,50 @@ class GetActiveDateUnsupportedMethodTestCase(unittest.TestCase):
 class OutputToJsonOptionalKeysTestCase(unittest.TestCase):
     """Cover the optional release/pr key branches in output_to_json."""
 
-    def test_includes_release_and_pr_keys_when_present(self):
-        """When repo_data dicts include 'release' and 'pr' marker keys, the JSON
-        output must include the additional daysSinceLastRelease and
-        daysSinceLastPR fields."""
+    def test_includes_release_and_pr_keys_when_additional_metrics_set(self):
+        """When additional_metrics includes 'release' and 'pr', the JSON output
+        must include daysSinceLastRelease and daysSinceLastPR populated from the
+        production-shaped repo_data dict that set_repo_data emits."""
         inactive_repos = [
             {
                 "url": "https://github.com/example/repo",
                 "days_inactive": 40,
                 "last_push_date": "2024-01-01",
                 "visibility": "public",
-                "release": True,
                 "days_since_last_release": 5,
-                "pr": True,
                 "days_since_last_pr": 2,
             }
         ]
 
-        result_json = output_to_json(inactive_repos, MagicMock())
+        result_json = output_to_json(
+            inactive_repos, MagicMock(), additional_metrics=["release", "pr"]
+        )
         result = json.loads(result_json)
 
         self.assertEqual(result[0]["daysSinceLastRelease"], 5)
         self.assertEqual(result[0]["daysSinceLastPR"], 2)
+
+    def test_release_only_metric_omits_pr_field(self):
+        """Only the requested metric should appear in the JSON; the unrequested
+        one (pr) should be absent even if days_since_last_pr is in the dict."""
+        inactive_repos = [
+            {
+                "url": "https://github.com/example/repo",
+                "days_inactive": 40,
+                "last_push_date": "2024-01-01",
+                "visibility": "public",
+                "days_since_last_release": 5,
+                "days_since_last_pr": 2,
+            }
+        ]
+
+        result_json = output_to_json(
+            inactive_repos, MagicMock(), additional_metrics=["release"]
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result[0]["daysSinceLastRelease"], 5)
+        self.assertNotIn("daysSinceLastPR", result[0])
 
 
 class OutputToJsonGithubOutputTestCase(unittest.TestCase):

--- a/test_stale_repos.py
+++ b/test_stale_repos.py
@@ -19,6 +19,7 @@ Example:
 import io
 import json
 import os
+import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
@@ -31,6 +32,7 @@ from stale_repos import (
     get_inactive_repos,
     is_repo_exempt,
     output_to_json,
+    set_repo_data,
 )
 
 
@@ -699,3 +701,204 @@ class TestAdditionalMetrics(unittest.TestCase):
             },
         ]
         self.assertEqual(inactive_repos, expected_inactive_repos)
+
+
+class GetInactiveReposWithExemptReposTestCase(unittest.TestCase):
+    """Verify get_inactive_repos honors the EXEMPT_REPOS environment variable."""
+
+    def setUp(self):
+        os.environ["EXEMPT_REPOS"] = "exempt_repo, another_exempt_repo"
+
+    def tearDown(self):
+        del os.environ["EXEMPT_REPOS"]
+
+    def test_exempt_repos_env_var_is_parsed_and_applied(self):
+        """EXEMPT_REPOS env var should exempt matching repos."""
+        mock_github = MagicMock()
+        mock_org = MagicMock()
+
+        forty_days_ago = datetime.now(timezone.utc) - timedelta(days=40)
+        exempt_repo = MagicMock(
+            html_url="https://github.com/example/exempt_repo",
+            pushed_at=forty_days_ago.isoformat(),
+            archived=False,
+            private=True,
+        )
+        exempt_repo.name = "exempt_repo"
+        exempt_repo.topics.return_value.names = []
+
+        included_repo = MagicMock(
+            html_url="https://github.com/example/included_repo",
+            pushed_at=forty_days_ago.isoformat(),
+            archived=False,
+            private=True,
+        )
+        included_repo.name = "included_repo"
+        included_repo.topics.return_value.names = []
+
+        mock_github.organization.return_value = mock_org
+        mock_org.repositories.return_value = [exempt_repo, included_repo]
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            inactive_repos = get_inactive_repos(mock_github, 30, "example")
+            output = mock_stdout.getvalue()
+
+        self.assertIn("Exempt repos: ['exempt_repo', 'another_exempt_repo']", output)
+        self.assertEqual(len(inactive_repos), 1)
+        self.assertEqual(
+            inactive_repos[0]["url"], "https://github.com/example/included_repo"
+        )
+
+
+class GetDaysSinceLastReleaseExceptionTestCase(unittest.TestCase):
+    """Cover the exception branches in get_days_since_last_release."""
+
+    def test_returns_none_on_type_error(self):
+        """A TypeError on the release iterator should return None and log a message."""
+        mock_repo = MagicMock(html_url="https://github.com/example/repo")
+        mock_repo.releases.return_value.__next__.side_effect = TypeError(
+            "ghost user release"
+        )
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            result = get_days_since_last_release(mock_repo)
+            output = mock_stdout.getvalue()
+
+        self.assertIsNone(result)
+        self.assertIn(
+            "https://github.com/example/repo had an exception trying to get the last release",
+            output,
+        )
+
+    def test_returns_none_when_no_releases(self):
+        """If the releases iterator is empty, return None without raising."""
+        mock_repo = MagicMock()
+        mock_repo.releases.return_value.__next__.side_effect = StopIteration
+
+        result = get_days_since_last_release(mock_repo)
+
+        self.assertIsNone(result)
+
+
+class GetDaysSinceLastPrExceptionTestCase(unittest.TestCase):
+    """Cover the exception branches in get_days_since_last_pr."""
+
+    def test_returns_none_when_no_pull_requests(self):
+        """If the pull_requests iterator is empty, return None without raising."""
+        mock_repo = MagicMock()
+        mock_repo.pull_requests.return_value.__next__.side_effect = StopIteration
+
+        result = get_days_since_last_pr(mock_repo)
+
+        self.assertIsNone(result)
+
+
+class GetActiveDateUnsupportedMethodTestCase(unittest.TestCase):
+    """Cover the ValueError branch in get_active_date when ACTIVITY_METHOD is bogus."""
+
+    @patch.dict(os.environ, {"ACTIVITY_METHOD": "not_a_real_method"})
+    def test_unsupported_activity_method_raises_value_error(self):
+        """Unsupported ACTIVITY_METHOD should raise ValueError (the raise sits
+        outside the github3 exception handler, so it propagates to the caller)."""
+        repo = MagicMock(html_url="https://github.com/example/repo")
+        with self.assertRaises(ValueError) as ctx:
+            get_active_date(repo)
+        self.assertIn(
+            "ACTIVITY_METHOD environment variable has unsupported value",
+            str(ctx.exception),
+        )
+
+
+class OutputToJsonOptionalKeysTestCase(unittest.TestCase):
+    """Cover the optional release/pr key branches in output_to_json."""
+
+    def test_includes_release_and_pr_keys_when_present(self):
+        """When repo_data dicts include 'release' and 'pr' marker keys, the JSON
+        output must include the additional daysSinceLastRelease and
+        daysSinceLastPR fields."""
+        inactive_repos = [
+            {
+                "url": "https://github.com/example/repo",
+                "days_inactive": 40,
+                "last_push_date": "2024-01-01",
+                "visibility": "public",
+                "release": True,
+                "days_since_last_release": 5,
+                "pr": True,
+                "days_since_last_pr": 2,
+            }
+        ]
+
+        result_json = output_to_json(inactive_repos, MagicMock())
+        result = json.loads(result_json)
+
+        self.assertEqual(result[0]["daysSinceLastRelease"], 5)
+        self.assertEqual(result[0]["daysSinceLastPR"], 2)
+
+
+class OutputToJsonGithubOutputTestCase(unittest.TestCase):
+    """Cover the GITHUB_OUTPUT environment variable branch in output_to_json."""
+
+    def test_writes_to_github_output_when_env_var_set(self):
+        """When GITHUB_OUTPUT is set, output_to_json should append a
+        `inactiveRepos=` line to the file path it points at."""
+        inactive_repos = [
+            {
+                "url": "https://github.com/example/repo",
+                "days_inactive": 40,
+                "last_push_date": "2024-01-01",
+                "visibility": "public",
+            }
+        ]
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".out"
+        ) as github_output_file:
+            github_output_path = github_output_file.name
+
+        try:
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": github_output_path}):
+                output_to_json(inactive_repos, MagicMock())
+
+            with open(github_output_path, "r", encoding="utf-8") as handle:
+                contents = handle.read()
+            self.assertIn("inactiveRepos=", contents)
+            self.assertIn("https://github.com/example/repo", contents)
+        finally:
+            os.remove(github_output_path)
+
+
+class SetRepoDataGithubExceptionTestCase(unittest.TestCase):
+    """Cover the GitHubException branches in set_repo_data."""
+
+    def test_github_exception_on_release_is_logged(self):
+        """A GitHubException raised when fetching releases should be caught and
+        logged; days_since_last_release should stay None."""
+        repo = MagicMock(html_url="https://github.com/example/repo")
+        repo.releases.side_effect = github3.exceptions.GitHubException("release boom")
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            result = set_repo_data(repo, 10, "2024-01-01", "public", ["release"])
+            output = mock_stdout.getvalue()
+
+        self.assertIsNone(result["days_since_last_release"])
+        self.assertIn(
+            "https://github.com/example/repo had an exception trying to get the last release",
+            output,
+        )
+
+    def test_github_exception_on_pr_is_logged(self):
+        """A GitHubException raised when fetching PRs should be caught and
+        logged; days_since_last_pr should stay None."""
+        repo = MagicMock(html_url="https://github.com/example/repo")
+        repo.pull_requests.side_effect = github3.exceptions.GitHubException("pr boom")
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            result = set_repo_data(repo, 10, "2024-01-01", "public", ["pr"])
+            output = mock_stdout.getvalue()
+
+        self.assertIsNone(result["days_since_last_pr"])
+        self.assertIn(
+            "https://github.com/example/repo had an exception trying to get the last PR",
+            output,
+        )


### PR DESCRIPTION
# Pull Request

## Proposed Changes

`stale-repos` ships with `--cov-fail-under=80`, and the working tree sat at ~90% line coverage with eleven branches uncovered across `auth.py`, `env.py`, and `stale_repos.py`. Raising coverage to 100% also matches the in-flight 100%-coverage push across the rest of the github-community-projects fleet.

While writing the masking-free tests I found a latent bug in `output_to_json` that all three review models independently flagged: `output_to_json` was gating the optional `daysSinceLastRelease` / `daysSinceLastPR` JSON fields on literal `"release"` / `"pr"` keys in the per-repo dict, but `set_repo_data` (the only production producer of those dicts) only ever writes `"days_since_last_release"` / `"days_since_last_pr"`. The result: the JSON output, including the value written to `$GITHUB_OUTPUT`, silently dropped both fields for every real caller, even when `ADDITIONAL_METRICS` was configured. Markdown output was unaffected because it gates on `additional_metrics` directly. I fixed this tightly-coupled bug in a separate commit by threading `additional_metrics` into `output_to_json` and mirroring the markdown writer's gate.

### What changed

- I added unit tests covering every previously-uncovered branch (see the per-file breakdown below).
- I added a `[report] exclude_lines` block to `.coveragerc` covering `pragma: no cover` (already implicit) and `if __name__ == .__main__.:`.
- I bumped `--cov-fail-under` from `80` to `100` in the Makefile.
- I fixed `output_to_json` to gate optional JSON fields on `additional_metrics` (separate commit), matching the markdown writer's semantics. The `main()` caller now passes `additional_metrics` to `output_to_json`.

### New test coverage (per uncovered branch)

| Module | Lines | New test |
| --- | --- | --- |
| `auth.py` | 47 | `test_auth_to_github_raises_when_connection_is_none` |
| `env.py` | 118-119 | `test_get_env_vars_loads_dotenv_when_not_test` |
| `stale_repos.py` | 148-149 | `test_exempt_repos_env_var_is_parsed_and_applied` |
| `stale_repos.py` | 190-193 | `test_returns_none_on_type_error` (`get_days_since_last_release`) |
| `stale_repos.py` | 194-195 | `test_returns_none_when_no_releases` |
| `stale_repos.py` | 210-211 | `test_returns_none_when_no_pull_requests` |
| `stale_repos.py` | 234 | `test_unsupported_activity_method_raises_value_error` |
| `stale_repos.py` | 277, 279 | `test_includes_release_and_pr_keys_when_additional_metrics_set` + `test_release_only_metric_omits_pr_field` |
| `stale_repos.py` | 286-287 | `test_writes_to_github_output_when_env_var_set` |
| `stale_repos.py` | 327-328 | `test_github_exception_on_release_is_logged` |
| `stale_repos.py` | 335-336 | `test_github_exception_on_pr_is_logged` |

### Before / after coverage

| Module | Baseline | After |
| --- | --- | --- |
| `auth.py` | 94% (16 stmts, 1 miss) | 100% |
| `env.py` | 96% (45 stmts, 2 miss) | 100% |
| `markdown.py` | 100% | 100% |
| `stale_repos.py` | 84% (119 stmts, 19 miss) | 100% |
| **Total** | **89.81%** | **100.00%** |

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

## Testing

- `make lint` - all 5 linters pass (flake8 syntax + warnings, isort, pylint 10.00/10, mypy, black). No suppression comments added.
- `make test` - 53 tests pass (6 sub-tests), `Required test coverage of 100% reached. Total coverage: 100.00%`. Verified on the Python 3.11 baseline used by the Makefile and on the Python 3.12 fallback that uv selected on this machine.
- Multi-model code review (Opus, Sonnet, GPT-5.5) run on the staged diff before opening. All three independently surfaced the `output_to_json` gating bug; the fix landed in this PR as a separate commit.

## Rollout

- No production behavior change beyond the `output_to_json` bug fix. With `ADDITIONAL_METRICS` unset (the default), the JSON output and `$GITHUB_OUTPUT` value are byte-identical to today. With `ADDITIONAL_METRICS=release` or `pr`, the JSON now correctly includes `daysSinceLastRelease` / `daysSinceLastPR`, which downstream consumers (e.g., scripts that read `$GITHUB_OUTPUT`) may have been silently missing.
- The threshold bump (`--cov-fail-under=80` → `100`) means any future PR that drops coverage will fail CI rather than slipping in unnoticed. This is the desired behavior and matches the fleet convention.

## Tradeoffs / Alternatives considered

- For the `output_to_json` fix I considered (a) gating on `"days_since_last_release" in repo_data` (always true post `set_repo_data`, would force the field into the output of callers who don't opt in - silent behavior change) and (b) threading `additional_metrics` through (chosen, mirrors `markdown.py`, no behavior change for non-opt-in callers).
- For the `if __name__ == "__main__":` line I considered adding `# pragma: no cover` inline instead of an `exclude_lines` entry. The `.coveragerc` rule is more discoverable and matches conventions in other repos in the fleet.
